### PR TITLE
chore: update Alamofire dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", from: "4.0.0"),
-        .package(url: "https://github.com/Alamofire/Alamofire.git", .exact("5.2.0"))
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.2.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Thanks for the lib, this lib helps me a lot.
The PR is for Package dependency only. Previously, the Alamofire dependency set to exact 5.2.0. 
This PR is set Aalamofire to from 5.2.0, users can use higher Alamofire version.
Thanks